### PR TITLE
fix: update Claude workflow permissions to write

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,9 +19,9 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:


### PR DESCRIPTION
## Problem

The Claude Code Action workflow was failing with:
```
fatal: could not read Username for 'https://github.com': No such device or address
Command failed: git fetch origin --depth=20 codex/portable-memory-mcp
```

## Solution

Updated permissions from `read` to `write` for:
- `contents` - needed to fetch/checkout PR branches and push commits
- `pull-requests` - needed to comment on and update PRs
- `issues` - needed to comment on and update issues

## Testing

After merging, trigger Claude on PR #2 with `@claude` to verify it works.