### PR TITLE
feat: Time-based cleanup for token budget turns (Issue #13)

### DIFF
--- a/extensions/memory-tribal/tests/token-budget.test.ts
+++ b/extensions/memory-tribal/tests/token-budget.test.ts
@@ -197,9 +197,9 @@ describe("TokenBudget", () => {
 
   describe("cleanupStaleTurns()", () => {
     it("removes turns older than maxAgeMs", () => {
+      vi.useFakeTimers();
       const now = Date.now();
 
-      // Record turns at different times
       vi.setSystemTime(now - 60_000); // 60s ago
       budget.recordUsage("s1", "old-turn", 10);
 
@@ -207,13 +207,10 @@ describe("TokenBudget", () => {
       budget.recordUsage("s1", "recent-turn", 20);
 
       vi.setSystemTime(now);
-
-      // Clean up turns older than 30s
       budget.cleanupStaleTurns(30_000);
 
       expect(budget.getUsage("s1", "old-turn").turn).toBe(0);
       expect(budget.getUsage("s1", "recent-turn").turn).toBe(20);
-
       vi.useRealTimers();
     });
 
@@ -228,6 +225,7 @@ describe("TokenBudget", () => {
     });
 
     it("removes all turns if all are stale", () => {
+      vi.useFakeTimers();
       const now = Date.now();
 
       vi.setSystemTime(now - 120_000);
@@ -242,6 +240,7 @@ describe("TokenBudget", () => {
     });
 
     it("returns count of removed turns", () => {
+      vi.useFakeTimers();
       const now = Date.now();
 
       vi.setSystemTime(now - 120_000);
@@ -259,13 +258,13 @@ describe("TokenBudget", () => {
     });
 
     it("updates timestamp on subsequent usage", () => {
+      vi.useFakeTimers();
       const now = Date.now();
 
-      // Record old turn
       vi.setSystemTime(now - 120_000);
       budget.recordUsage("s1", "refreshed", 10);
 
-      // Record again recently — should update timestamp
+      // Record again recently — refreshes timestamp
       vi.setSystemTime(now - 5_000);
       budget.recordUsage("s1", "refreshed", 5);
 


### PR DESCRIPTION
## Summary

Adds time-based cleanup to complement the existing count-based cleanup for token budget turn tracking. Turns from old/stale sessions are now evicted based on last activity time.

## Problem

The existing cleanup only triggers when turn count exceeds 200, keeping the last 100 by insertion order. Turns from old sessions that never hit the threshold accumulate indefinitely.

## Changes

### `token-budget.ts`
- **Timestamp tracking**: `turnTimestamps` map records `Date.now()` on each `recordUsage()` call, updated on re-use
- **`cleanupStaleTurns(maxAgeMs)`**: Removes turns whose last activity exceeds the max age. Returns count of removed turns.
- **`cleanupOldTurns()` fix**: Now preserves timestamps for kept turns (was clearing all timestamps before restoring)

### `index.ts`
- Calls `cleanupStaleTurns(30 * 60 * 1000)` after each usage recording — evicts turns inactive for >30 minutes

## Tests (5 new, 28 total)
- Removes turns older than maxAgeMs
- Keeps all turns if none are stale
- Removes all turns if all are stale
- Returns accurate removed count
- Updates timestamp on subsequent usage (refresh)

## Test Results
- 178 TS tests pass (full suite)
- 2 pre-existing failures (deprecated methods, unrelated)

Closes #13