### PR TITLE
fix: Add setuptools package discovery for src layout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,9 @@
 requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools.packages.find]
+where = ["src"]
+
 [project]
 name = "tribalmemory"
 version = "0.1.0"


### PR DESCRIPTION
## What

Without `[tool.setuptools.packages.find]` in pyproject.toml, `pip install .` installs the package as `UNKNOWN 0.0.0` and `import tribalmemory` fails. The wheel build (`python -m build`) works because it uses a different code path, but direct source installs break.

## Fix

Added:
```toml
[tool.setuptools.packages.find]
where = ["src"]
```

## Verified

```
$ pip install .
Successfully installed tribalmemory-0.1.0

$ python -c "import tribalmemory; print('OK')"
OK

$ tribalmemory --help
usage: tribalmemory [-h] {init,serve,mcp} ...

$ tribalmemory init --local --force
✅ Config written
```

Also verified end-to-end: store + recall via HTTP API with local Ollama embeddings ✅