### PR TITLE
feat: Add --auto-capture flag for proactive memory usage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ where = ["src"]
 
 [project]
 name = "tribalmemory"
-version = "0.1.2"
+version = "0.1.3"
 description = "Shared memory infrastructure for multi-instance AI agents"
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Problem

Just connecting the MCP server isn't enough — Claude Code won't proactively use `tribal_remember` and `tribal_recall` unless explicitly told to. Users have to manually say "remember this" every time.

## Solution

New `--auto-capture` flag for `tribalmemory init`:

```bash
tribalmemory init --local --claude-code --auto-capture
```

### What it does:

1. **Writes instructions to `~/.claude/CLAUDE.md`** — Claude Code's global instructions file. Tells Claude to:
   - Proactively call `tribal_remember` after completing tasks, making decisions, or learning something
   - Call `tribal_recall` before answering questions about prior work
   - Includes guidance on what makes good vs. bad memories

2. **Sets `auto_capture: true` in config.yaml** — for future server-side hooks

3. **Shows a hint** when not used:
   ```
   💡 Want Claude to remember things automatically?
      tribalmemory init --auto-capture --force
   ```

### Safety features:
- **Appends** to existing CLAUDE.md (doesn't clobber)
- **Idempotent** — skips if instructions already present (section marker check)
- **Opt-in** — default is off, no behavior change without the flag

## Tests

6 new tests:
- `test_auto_capture_creates_claude_instructions` — creates CLAUDE.md with tribal_remember/recall
- `test_auto_capture_appends_to_existing_claude_md` — preserves existing content
- `test_auto_capture_skips_if_already_present` — idempotent, no duplicates
- `test_no_auto_capture_skips_claude_md` — no CLAUDE.md without flag
- `test_auto_capture_sets_config_flag` — config.yaml gets auto_capture: true
- `test_no_auto_capture_omits_config_flag` — config clean without flag

All 26 CLI tests pass.

## Version
Bumped to v0.1.3.