### PR TITLE
feat: Extend --auto-capture to support Codex CLI (AGENTS.md)

### DIFF
--- a/src/tribalmemory/cli.py
+++ b/src/tribalmemory/cli.py
@@ -197,10 +197,14 @@ def _setup_auto_capture(claude_code: bool = False, codex: bool = False) -> None:
     
     Skips if instructions are already present (idempotent).
     """
+    # If no specific flag, write to both (default behavior)
+    if not claude_code and not codex:
+        claude_code = codex = True
+
     targets = []
-    if claude_code or (not claude_code and not codex):
+    if claude_code:
         targets.append(("Claude Code", Path.home() / CLAUDE_INSTRUCTIONS_FILE))
-    if codex or (not claude_code and not codex):
+    if codex:
         targets.append(("Codex CLI", Path.home() / CODEX_INSTRUCTIONS_FILE))
 
     for label, instructions_path in targets:
@@ -424,7 +428,7 @@ def main() -> None:
     init_parser.add_argument("--codex", action="store_true",
                              help="Configure Codex CLI MCP integration")
     init_parser.add_argument("--auto-capture", action="store_true",
-                             help="Enable auto-capture (writes CLAUDE.md instructions)")
+                             help="Enable auto-capture (writes instructions to agent config files)")
     init_parser.add_argument("--instance-id", type=str, default=None,
                              help="Instance identifier (default: 'default')")
     init_parser.add_argument("--force", action="store_true",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -319,6 +319,16 @@ class TestAutoCapture:
         claude_md = cli_env / ".claude" / "CLAUDE.md"
         assert not claude_md.exists()
 
+    def test_auto_capture_claude_only_skips_codex(self, cli_env):
+        """--auto-capture --claude-code (no --codex) should only write CLAUDE.md."""
+        result = cmd_init(FakeArgs(auto_capture=True, claude_code=True))
+
+        assert result == 0
+        claude_md = cli_env / CLAUDE_INSTRUCTIONS_FILE
+        codex_md = cli_env / CODEX_INSTRUCTIONS_FILE
+        assert claude_md.exists()
+        assert not codex_md.exists()
+
     def test_auto_capture_with_codex_writes_agents_md(self, cli_env):
         """--auto-capture --codex should write to ~/.codex/AGENTS.md."""
         result = cmd_init(FakeArgs(auto_capture=True, codex=True))


### PR DESCRIPTION
## Problem

`--auto-capture` only writes instructions to Claude Code's `~/.claude/CLAUDE.md`. Codex CLI users get no auto-capture behavior.

## Solution

Auto-capture now writes to both agent instruction files:

| Flag combo | Claude Code (`~/.claude/CLAUDE.md`) | Codex CLI (`~/.codex/AGENTS.md`) |
|---|---|---|
| `--auto-capture --claude-code` | ✅ | — |
| `--auto-capture --codex` | — | ✅ |
| `--auto-capture --claude-code --codex` | ✅ | ✅ |
| `--auto-capture` (bare) | ✅ | ✅ |

All writes are:
- **Idempotent** — section marker prevents duplicates
- **Append-safe** — existing instructions preserved
- **Cross-platform** — same Path-based approach

### Refactoring

Extracted `_write_instructions_file()` helper so the same logic handles both files without duplication.

## Tests

5 new Codex-specific tests:
- `test_auto_capture_with_codex_writes_agents_md`
- `test_auto_capture_with_both_writes_both_files`
- `test_auto_capture_bare_writes_both_files`
- `test_auto_capture_codex_appends_to_existing`
- `test_auto_capture_codex_idempotent`

All 31 CLI tests pass.