### PR TITLE
feat: batch temporal extraction + Unicode fallback tests (#60, #62)

### DIFF
--- a/src/tribalmemory/services/memory.py
+++ b/src/tribalmemory/services/memory.py
@@ -166,7 +166,7 @@ class TribalMemoryService(IMemoryService):
         return result
 
     def _extract_and_store_temporal(
-        self, content: str, entry: "MemoryEntry"
+        self, content: str, entry: MemoryEntry
     ) -> None:
         """Extract temporal facts from *content* and persist them.
 

--- a/src/tribalmemory/services/temporal.py
+++ b/src/tribalmemory/services/temporal.py
@@ -119,7 +119,7 @@ class TemporalExtractor:
     # Quick-check pattern: combined lightweight regex that detects whether text
     # contains *any* temporal signal.  Used by ``has_temporal_signal()`` to
     # short-circuit full extraction for texts that obviously have no dates.
-    _QUICK_CHECK_KEYWORDS = (
+    _QUICK_CHECK_PATTERN = (
         r'\byesterday\b|\btoday\b|\btomorrow\b|\btonight\b'
         r'|\blast\s+(?:week|month|year|night|monday|tuesday|wednesday'
         r'|thursday|friday|saturday|sunday)\b'
@@ -146,7 +146,7 @@ class TemporalExtractor:
             re.IGNORECASE
         )
         self._quick_check_regex = re.compile(
-            self._QUICK_CHECK_KEYWORDS, re.IGNORECASE
+            self._QUICK_CHECK_PATTERN, re.IGNORECASE
         )
 
     def has_temporal_signal(self, text: str) -> bool:
@@ -475,10 +475,10 @@ class TemporalExtractor:
         """
         results: list[list[TemporalEntity]] = []
         for text, ref in items:
-            if not text or not self.has_temporal_signal(text):
-                results.append([])
-            else:
+            if text and self.has_temporal_signal(text):
                 results.append(self.extract(text, ref))
+            else:
+                results.append([])
         return results
 
     def batch_extract_with_context(
@@ -498,10 +498,10 @@ class TemporalExtractor:
         """
         results: list[list[TemporalRelationship]] = []
         for text, ref in items:
-            if not text or not self.has_temporal_signal(text):
-                results.append([])
-            else:
+            if text and self.has_temporal_signal(text):
                 results.append(self.extract_with_context(text, ref))
+            else:
+                results.append([])
         return results
 
     def _find_temporal_subject(self, text: str, expression: str) -> Optional[str]:


### PR DESCRIPTION
## Summary

Closes #60 and #62 in a single PR.

### Issue #60 — Unicode month names fallback test

Added `TestUnicodeFallback` (4 tests) that mocks `DATEPARSER_AVAILABLE=False` and verifies the fallback parser:
- Gracefully handles non-ASCII month names (French, German, Japanese) — no crashes
- Still resolves English relative expressions correctly without dateparser
- Handles January→December year wrap

### Issue #62 — Batch temporal extraction optimization

**New APIs on `TemporalExtractor`:**
- `has_temporal_signal(text)` — fast O(1) regex pre-check; skips full extraction for texts without any temporal signals
- `batch_extract(items)` — process multiple `(text, reference_time)` pairs; skips non-temporal items via pre-check
- `batch_extract_with_context(items)` — same, returns `TemporalRelationship` lists

**memory.py refactoring:**
- Extracted `_extract_and_store_temporal()` as reusable method
- `remember()` now calls `has_temporal_signal()` before full extraction — zero dateparser overhead for non-temporal content

### Tests

27 new tests (582 total passing, 5 skipped):
- `TestUnicodeFallback`: 4 tests
- `TestHasTemporalSignal`: 6 tests (relative, absolute, month names, edge cases)
- `TestBatchExtract`: 6 tests (basic, empty, skip, context, order, 500-item volume)
- `TestPreCheckIntegration`: 1 test (pre-check agrees with full extract)