### PR TITLE
test: HTTP + MCP + concurrent session integration tests (#46)

### DIFF
--- a/tests/test_session_integration.py
+++ b/tests/test_session_integration.py
@@ -46,7 +46,12 @@ def _parse(result: Any) -> dict:
         if not text and isinstance(block, dict):
             text = block.get("text")
         if text:
-            return json.loads(text)
+            try:
+                return json.loads(text)
+            except json.JSONDecodeError as e:
+                raise ValueError(
+                    f"Malformed JSON in MCP response: {e}\nRaw text: {text!r}"
+                ) from e
     raise ValueError(f"Could not parse result: {result}")
 
 
@@ -89,6 +94,7 @@ SAMPLE_MESSAGES_JSON = json.dumps(SAMPLE_MESSAGES_LIST)
 @pytest.fixture
 def embedding_service():
     emb = MockEmbeddingService(embedding_dim=64)
+    # Export/import tools read these via getattr; constructor doesn't set them
     emb.dimensions = 64
     emb.model = "mock-test-model"
     return emb


### PR DESCRIPTION
## Summary
Closes #46 — Adds integration tests for session HTTP endpoints and MCP tools.

## Changes
**New file:** `tests/test_session_integration.py` (571 lines, 21 tests)

### HTTP Endpoint Tests (10)
- **POST /v1/sessions/ingest:** success, instance_id override, empty messages, invalid format, missing session_id
- **GET /v1/sessions/search:** empty store, after ingest, session filter, pagination fields, missing query

### MCP Tool Tests (8)
- **tribal_sessions_ingest:** via MCP, instance override, invalid messages
- **tribal_recall sources:** memories-only, sessions-only, all, invalid sources, empty sessions

### Concurrent Ingestion Tests (3)
- Parallel ingestion of 10 different sessions
- Same-session delta ingestion (5 concurrent appends)
- Concurrent ingest + search (no crashes/deadlocks)

## Test Results
```
647 passed, 5 skipped in 46s
```

## Notes
- Uses `min_relevance=-1` for HTTP tests to handle MockEmbeddingService hash-based similarity (can produce slightly negative scores for dissimilar texts)
- MCP tests handle `min_relevance` clamping (`[0.0, 1.0]`) by testing response structure where needed
- Each fixture creates isolated mock backends (no shared state between tests)