### PR TITLE
fix: detect uv tool environments and use uv pip install for fastembed

### DIFF
--- a/src/tribalmemory/cli.py
+++ b/src/tribalmemory/cli.py
@@ -181,11 +181,66 @@ def load_env_file() -> None:
                 os.environ[k] = v
 
 
-def _auto_install_fastembed() -> bool:
-    """Prompt to install fastembed, then install via the running Python.
+def _is_uv_environment() -> bool:
+    """Detect if we're running inside a uv-managed tool environment."""
+    # uv tool environments have uv-specific paths and lack pip
+    venv_path = str(Path(sys.executable).resolve())
+    if "/uv/tools/" in venv_path or "\\uv\\tools\\" in venv_path:
+        return True
+    # Also check: pip module missing + uv available on PATH
+    pip_check = subprocess.run(
+        [sys.executable, "-m", "pip", "--version"],
+        capture_output=True,
+    )
+    if pip_check.returncode != 0:
+        uv_check = shutil.which("uv")
+        if uv_check:
+            return True
+    return False
 
-    Uses ``sys.executable -m pip install --quiet fastembed`` so it works
-    inside uv tool environments, regular venvs, and system Python alike.
+
+def _install_fastembed(interactive: bool) -> bool:
+    """Try to install fastembed using the best available installer.
+
+    Tries pip first, falls back to uv for uv-managed environments.
+
+    Returns True if installation succeeded.
+    """
+    suppress = not interactive
+    out = subprocess.DEVNULL if suppress else None
+
+    # In uv environments, use uv pip install directly
+    if _is_uv_environment():
+        uv_bin = shutil.which("uv")
+        if uv_bin:
+            print(f"   Installing fastembed via uv (detected uv environment)...")
+            cmd = [
+                uv_bin, "pip", "install",
+                "--python", sys.executable,
+                "fastembed",
+            ]
+            try:
+                subprocess.check_call(cmd, stdout=out, stderr=out)
+                return True
+            except subprocess.CalledProcessError:
+                pass  # Fall through to pip attempt
+
+    # Standard pip install
+    print(f"   Installing fastembed via pip...")
+    cmd = [sys.executable, "-m", "pip", "install", "--quiet", "fastembed"]
+    try:
+        subprocess.check_call(cmd, stdout=out, stderr=out)
+        return True
+    except subprocess.CalledProcessError:
+        return False
+
+
+def _auto_install_fastembed() -> bool:
+    """Prompt to install fastembed, then install via pip or uv.
+
+    Detects uv tool environments (which lack pip) and uses
+    ``uv pip install`` as fallback. Works in uv tool environments,
+    regular venvs, and system Python alike.
 
     Returns:
         True if fastembed is available after the attempt (import succeeds).
@@ -199,24 +254,21 @@ def _auto_install_fastembed() -> bool:
         if answer and answer not in ("y", "yes"):
             print()
             print("   To install manually:")
-            print(f"   {sys.executable} -m pip install fastembed")
+            if _is_uv_environment():
+                print(f"   uv pip install --python {sys.executable} fastembed")
+            else:
+                print(f"   {sys.executable} -m pip install fastembed")
             print("   Or use --openai or --ollama instead.")
             return False
     else:
         print("   Auto-installing (non-interactive)...")
 
-    print(f"   Installing fastembed via {sys.executable}...")
-    try:
-        cmd = [sys.executable, "-m", "pip", "install", "--quiet", "fastembed"]
-        if interactive:
-            subprocess.check_call(cmd)
-        else:
-            subprocess.check_call(
-                cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
-            )
-    except subprocess.CalledProcessError:
+    if not _install_fastembed(interactive):
         print("❌ Installation failed. Try manually:")
-        print(f"   {sys.executable} -m pip install fastembed")
+        if _is_uv_environment():
+            print(f"   uv pip install --python {sys.executable} fastembed")
+        else:
+            print(f"   {sys.executable} -m pip install fastembed")
         return False
 
     # Verify in a clean subprocess — the current process may have
@@ -230,7 +282,10 @@ def _auto_install_fastembed() -> bool:
         return True
 
     print("❌ Install completed but import still fails.")
-    print(f"   Try: {sys.executable} -m pip install fastembed")
+    if _is_uv_environment():
+        print(f"   Try: uv pip install --python {sys.executable} fastembed")
+    else:
+        print(f"   Try: {sys.executable} -m pip install fastembed")
     return False
 
 


### PR DESCRIPTION
## Problem

`tribalmemory init` fails in uv tool environments because `sys.executable -m pip install` doesn't work — uv-managed venvs don't include pip.

**Reproduction (macOS):**
```
$ uv tool install tribalmemory
$ tribalmemory init
📦 FastEmbed is not installed (needed for local embeddings).
   Install it now? [Y/n] y
   Installing fastembed via /Users/.../uv/tools/tribalmemory/bin/python3...
   /Users/.../uv/tools/tribalmemory/bin/python3: No module named pip
❌ Installation failed.
```

## Fix

### New helpers:
- **`_is_uv_environment()`** — detects uv tool environments via:
  1. Path inspection (`/uv/tools/` in `sys.executable`)
  2. Fallback: pip module missing + `uv` on PATH

- **`_install_fastembed(interactive)`** — tries the best installer:
  1. If uv environment detected → `uv pip install --python <exe> fastembed`
  2. Falls back to `sys.executable -m pip install fastembed`
  3. Error messages show the correct command for the user's environment

### Tests:
- `test_init_fastembed_uv_environment_install` — verifies uv pip install is used
- `test_init_fastembed_uv_fallback_to_pip` — verifies graceful fallback when uv install fails

**46 CLI tests passing** (44 existing + 2 new).