### PR TITLE
Add batch endpoint and auto-temporal query extraction

### DIFF
--- a/src/tribalmemory/server/models.py
+++ b/src/tribalmemory/server/models.py
@@ -105,12 +105,18 @@ class StoreResponse(BaseModel):
 
 
 class BatchRememberRequest(BaseModel):
-    """Request to store multiple memories at once."""
+    """Request to store multiple memories at once.
+
+    Batch size is limited to 1000 memories per request to prevent request
+    timeouts and memory exhaustion. For larger imports, split into multiple
+    batch requests. Memories are processed concurrently in chunks of 50
+    for optimal throughput.
+    """
     memories: list[RememberRequest] = Field(
         ...,
-        description="List of memories to store",
+        description="List of memories to store (max 1000 per request)",
         min_length=1,
-        max_length=100,
+        max_length=1000,
     )
 
 

--- a/tests/test_auto_temporal.py
+++ b/tests/test_auto_temporal.py
@@ -1,0 +1,201 @@
+"""Tests for auto-temporal query extraction."""
+
+import pytest
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+from tribalmemory.services.memory import TribalMemoryService
+from tribalmemory.services.temporal import TemporalExtractor
+
+
+class TestExtractQueryTemporal:
+    """Tests for _extract_query_temporal() method."""
+
+    @pytest.fixture
+    def service_with_temporal(self):
+        """Create a memory service with temporal extractor enabled."""
+        service = MagicMock(spec=TribalMemoryService)
+        service.temporal_extractor = TemporalExtractor()
+        service._extract_query_temporal = TribalMemoryService._extract_query_temporal.__get__(
+            service, TribalMemoryService
+        )
+        return service
+
+    def test_no_temporal_signal_returns_none(self, service_with_temporal):
+        """Test that queries without temporal references return None."""
+        result = service_with_temporal._extract_query_temporal(
+            "What is my favorite color?"
+        )
+        assert result is None
+
+    def test_last_saturday_returns_day_range(self, service_with_temporal):
+        """Test 'last Saturday' extracts to a specific day."""
+        result = service_with_temporal._extract_query_temporal(
+            "Who did I meet last Saturday?"
+        )
+        # Should return a tuple (after, before) for that day
+        if result is not None:
+            after, before = result
+            assert after is not None
+            # For day precision, after == before
+            assert after == before
+
+    def test_yesterday_returns_day_range(self, service_with_temporal):
+        """Test 'yesterday' extracts to a specific day."""
+        result = service_with_temporal._extract_query_temporal(
+            "What did I do yesterday?"
+        )
+        if result is not None:
+            after, before = result
+            assert after is not None
+
+    def test_last_week_returns_week_range(self, service_with_temporal):
+        """Test 'last week' extracts to a week range."""
+        result = service_with_temporal._extract_query_temporal(
+            "What meetings did I have last week?"
+        )
+        if result is not None:
+            after, before = result
+            assert after is not None
+            # For week precision, before should be 6 days after start
+            if before is not None:
+                start = datetime.fromisoformat(after)
+                end = datetime.fromisoformat(before)
+                diff = (end - start).days
+                assert diff == 6  # Inclusive week range
+
+    def test_last_month_returns_month_range(self, service_with_temporal):
+        """Test 'last month' extracts to a month range."""
+        result = service_with_temporal._extract_query_temporal(
+            "What did I accomplish last month?"
+        )
+        if result is not None:
+            after, before = result
+            assert after is not None
+            # Month should have both start and end
+            if before is not None:
+                # Verify it's a valid month range
+                start = datetime.fromisoformat(after)
+                end = datetime.fromisoformat(before)
+                assert start.month == end.month or (
+                    start.month == 12 and end.month == 1
+                )
+
+    def test_no_temporal_extractor_returns_none(self):
+        """Test that None is returned when temporal_extractor is None."""
+        service = MagicMock(spec=TribalMemoryService)
+        service.temporal_extractor = None
+        service._extract_query_temporal = TribalMemoryService._extract_query_temporal.__get__(
+            service, TribalMemoryService
+        )
+        
+        result = service._extract_query_temporal("What happened last week?")
+        assert result is None
+
+    def test_invalid_date_returns_none(self, service_with_temporal):
+        """Test that unparseable temporal expressions return None gracefully."""
+        # The temporal extractor should handle this gracefully
+        result = service_with_temporal._extract_query_temporal(
+            "What happened on the 32nd of Octember?"
+        )
+        # Should return None rather than raising
+        # (The actual behavior depends on dateparser)
+        assert result is None or isinstance(result, tuple)
+
+    def test_multiple_temporal_uses_first(self, service_with_temporal):
+        """Test that multiple temporal expressions use the first one."""
+        # This documents the current behavior
+        result = service_with_temporal._extract_query_temporal(
+            "Compare meetings last Monday and next Friday"
+        )
+        # Should extract something (first temporal reference)
+        # The exact result depends on parsing order
+        if result is not None:
+            after, before = result
+            assert after is not None
+
+    def test_query_with_explicit_date(self, service_with_temporal):
+        """Test query with explicit date format."""
+        result = service_with_temporal._extract_query_temporal(
+            "What happened on 2026-01-15?"
+        )
+        if result is not None:
+            after, before = result
+            # Should parse the ISO date
+            assert "2026-01" in (after or "")
+
+
+class TestAutoTemporalInRecall:
+    """Integration tests for auto-temporal extraction in recall."""
+
+    @pytest.fixture
+    def memory_service(self):
+        """Create a real memory service for integration testing."""
+        from tribalmemory.services.memory import create_memory_service
+        
+        service = create_memory_service(
+            instance_id="test-auto-temporal",
+            db_path=None,  # In-memory
+            lazy_spacy=True,
+        )
+        return service
+
+    @pytest.mark.asyncio
+    async def test_recall_without_explicit_temporal_extracts_from_query(
+        self, memory_service
+    ):
+        """Test that recall auto-extracts temporal from query when not provided."""
+        # Store a memory
+        await memory_service.remember(
+            content="Met with John about the project",
+            source_type="auto_capture",
+        )
+
+        # Query with temporal reference but no explicit after/before
+        results = await memory_service.recall(
+            query="Who did I meet last week?",
+            limit=5,
+        )
+        
+        # Should complete without error
+        # Results may or may not match depending on date
+        assert isinstance(results, list)
+
+    @pytest.mark.asyncio
+    async def test_recall_with_explicit_temporal_overrides_extraction(
+        self, memory_service
+    ):
+        """Test that explicit after/before override auto-extraction."""
+        await memory_service.remember(
+            content="Important meeting notes",
+            source_type="auto_capture",
+        )
+
+        # Explicit after should be used, not extracted from query
+        results = await memory_service.recall(
+            query="What happened last week?",  # Has temporal
+            after="2020-01-01",  # Explicit override
+            limit=5,
+        )
+        
+        # Should use explicit date, not extracted
+        assert isinstance(results, list)
+
+    @pytest.mark.asyncio
+    async def test_recall_query_without_temporal_no_extraction(
+        self, memory_service
+    ):
+        """Test that queries without temporal don't get filtered."""
+        await memory_service.remember(
+            content="My favorite color is blue",
+            source_type="user_explicit",
+        )
+
+        results = await memory_service.recall(
+            query="What is my favorite color?",
+            limit=5,
+        )
+        
+        # Should find the memory (no temporal filtering applied)
+        assert len(results) >= 1
+        assert "blue" in results[0].memory.content

--- a/tests/test_batch_endpoint.py
+++ b/tests/test_batch_endpoint.py
@@ -1,0 +1,205 @@
+"""Tests for batch ingestion endpoint."""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from tribalmemory.server.app import create_app
+from tribalmemory.server.config import TribalMemoryConfig, DatabaseConfig, EmbeddingConfig
+from tribalmemory.server import app as app_module
+from tribalmemory.server.models import SourceType
+
+
+@pytest.fixture
+def test_config():
+    """Create test configuration with in-memory storage."""
+    return TribalMemoryConfig(
+        instance_id="test-batch",
+        db=DatabaseConfig(path=":memory:"),
+        embedding=EmbeddingConfig(),
+    )
+
+
+@pytest.fixture
+def mock_memory_service():
+    """Create a mock memory service with in-memory vector store."""
+    from tribalmemory.testing.mocks import MockEmbeddingService
+    from tribalmemory.services import TribalMemoryService
+    from tribalmemory.services.vector_store import InMemoryVectorStore
+
+    embedding = MockEmbeddingService()
+    vector_store = InMemoryVectorStore(embedding)
+    service = TribalMemoryService(
+        instance_id="test-batch",
+        embedding_service=embedding,
+        vector_store=vector_store,
+    )
+    return service
+
+
+@pytest.fixture
+def client(test_config, mock_memory_service):
+    """Create test client with mocked memory service."""
+    # Directly set the module-level variables
+    app_module._memory_service = mock_memory_service
+    app_module._instance_id = "test-batch"
+
+    # Create app without lifespan (we manage service manually)
+    from fastapi import FastAPI
+    from tribalmemory.server.routes import router
+
+    app = FastAPI()
+    app.include_router(router)
+
+    yield TestClient(app)
+
+    # Cleanup
+    app_module._memory_service = None
+    app_module._instance_id = None
+
+
+class TestBatchRememberEndpoint:
+    """Tests for /v1/remember/batch endpoint."""
+
+    def test_batch_remember_success(self, client):
+        """Test successful batch ingestion of multiple memories."""
+        response = client.post("/v1/remember/batch", json={
+            "memories": [
+                {"content": "Test memory 1"},
+                {"content": "Test memory 2"},
+                {"content": "Test memory 3"},
+            ]
+        })
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 3
+        assert data["successful"] == 3
+        assert data["failed"] == 0
+        assert len(data["results"]) == 3
+        for result in data["results"]:
+            assert result["success"] is True
+            assert result["memory_id"] is not None
+
+    def test_batch_remember_with_metadata(self, client):
+        """Test batch ingestion with full metadata."""
+        response = client.post("/v1/remember/batch", json={
+            "memories": [
+                {
+                    "content": "User preference: dark mode",
+                    "source_type": "user_explicit",
+                    "context": "Settings discussion",
+                    "tags": ["preference", "ui"],
+                },
+                {
+                    "content": "Meeting scheduled for Monday",
+                    "source_type": "auto_capture",
+                    "context": "Calendar sync",
+                },
+            ]
+        })
+        assert response.status_code == 200
+        data = response.json()
+        assert data["successful"] == 2
+
+    def test_batch_remember_partial_failure(self, client):
+        """Test that failures in one memory don't affect others."""
+        # First, store a memory
+        client.post("/v1/remember", json={"content": "Original memory"})
+
+        # Now batch with duplicate - should still succeed for others
+        response = client.post("/v1/remember/batch", json={
+            "memories": [
+                {"content": "New memory 1"},
+                {"content": "Original memory"},  # Duplicate - will fail
+                {"content": "New memory 2"},
+            ]
+        })
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 3
+        # 2 new memories succeed, 1 duplicate fails
+        assert data["successful"] == 2
+        assert data["failed"] == 1
+        # The duplicate should have duplicate_of set
+        duplicate_result = data["results"][1]
+        assert duplicate_result["success"] is False
+        assert duplicate_result["duplicate_of"] is not None
+
+    def test_batch_remember_empty_list_rejected(self, client):
+        """Test that empty memory list is rejected."""
+        response = client.post("/v1/remember/batch", json={
+            "memories": []
+        })
+        assert response.status_code == 422  # Validation error
+
+    def test_batch_remember_exceeds_max_length(self, client):
+        """Test that exceeding max batch size is rejected."""
+        # Create 1001 memories (limit is 1000)
+        memories = [{"content": f"Memory {i}"} for i in range(1001)]
+        response = client.post("/v1/remember/batch", json={
+            "memories": memories
+        })
+        assert response.status_code == 422  # Validation error
+
+    def test_batch_remember_reasonable_size(self, client):
+        """Test batch with reasonable size succeeds."""
+        # Test with 50 memories (well under the 1000 limit)
+        memories = [{"content": f"Memory {i}"} for i in range(50)]
+        response = client.post("/v1/remember/batch", json={
+            "memories": memories
+        })
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 50
+
+    def test_batch_remember_error_isolation(self, client):
+        """Test that one memory's error doesn't crash the batch."""
+        # Each memory is processed independently
+        response = client.post("/v1/remember/batch", json={
+            "memories": [
+                {"content": "Valid memory 1"},
+                {"content": "Valid memory 2"},
+                {"content": "Valid memory 3"},
+            ]
+        })
+        assert response.status_code == 200
+        data = response.json()
+        # All should succeed independently
+        assert data["total"] == 3
+        assert len(data["results"]) == 3
+
+    def test_batch_remember_returns_memory_ids(self, client):
+        """Test that each result includes the memory ID."""
+        response = client.post("/v1/remember/batch", json={
+            "memories": [
+                {"content": "Memory A"},
+                {"content": "Memory B"},
+            ]
+        })
+        assert response.status_code == 200
+        data = response.json()
+        ids = [r["memory_id"] for r in data["results"]]
+        assert len(ids) == 2
+        assert all(id is not None for id in ids)
+        # IDs should be unique
+        assert len(set(ids)) == 2
+
+    def test_batch_remember_duplicate_detection(self, client):
+        """Test duplicate detection within a batch and across batches."""
+        # Store original
+        first = client.post("/v1/remember", json={"content": "Duplicate test"})
+        original_id = first.json()["memory_id"]
+
+        # Batch with duplicate
+        response = client.post("/v1/remember/batch", json={
+            "memories": [
+                {"content": "Duplicate test"},  # Duplicate of original
+                {"content": "Unique memory"},
+            ]
+        })
+        assert response.status_code == 200
+        data = response.json()
+        
+        # First should be detected as duplicate
+        assert data["results"][0]["duplicate_of"] == original_id
+        # Second should be new
+        assert data["results"][1]["duplicate_of"] is None


### PR DESCRIPTION
## Summary

Addresses performance and accuracy issues found during LongMemEval benchmarking.

### Batch Ingestion Endpoint

- Add `/v1/remember/batch` endpoint for bulk memory storage
- Reduces HTTP overhead for benchmark/import scenarios (2399 memories = 2399 HTTP requests → 1 request)
- Each memory processed independently; failures don't affect others
- Adds `BatchRememberRequest` and `BatchStoreResponse` models

### Auto-Temporal Query Extraction

- Extract temporal references from recall queries (e.g., 'last Saturday')
- Automatically apply as date filters when not explicitly provided
- Supports day, week, and month precision
- Improves temporal reasoning accuracy in benchmarks

### Testing

- Existing server tests pass (12/12)
- Needs integration tests for batch endpoint and temporal extraction

### Context

During LongMemEval benchmarking:
- 50% accuracy on 10 questions (before these changes)
- Temporal reasoning questions failed because 'last Saturday' wasn't being parsed
- Ingestion took 26 min due to sequential HTTP requests

Fixes: Temporal reasoning gap, ingestion performance