### PR TITLE
feat: add --version flag to CLI (#112)

### DIFF
--- a/src/tribalmemory/cli.py
+++ b/src/tribalmemory/cli.py
@@ -12,6 +12,7 @@ import os
 import shutil
 import subprocess
 import sys
+from importlib.metadata import version as metadata_version
 from pathlib import Path
 
 try:
@@ -23,6 +24,18 @@ try:
     import tomli_w  # For writing TOML
 except ImportError:
     tomli_w = None  # type: ignore
+
+def _get_version() -> str:
+    """Get the installed package version via importlib.metadata.
+
+    Falls back to 'unknown' if the package metadata is unavailable
+    (e.g. running from source without installing).
+    """
+    try:
+        return metadata_version("tribalmemory")
+    except Exception:
+        return "unknown"
+
 
 TRIBAL_DIR = Path.home() / ".tribal-memory"
 CONFIG_FILE = TRIBAL_DIR / "config.yaml"
@@ -593,6 +606,11 @@ def main() -> None:
     parser = argparse.ArgumentParser(
         prog="tribalmemory",
         description="Tribal Memory — Shared memory for AI agents",
+    )
+    parser.add_argument(
+        "--version", "-V",
+        action="version",
+        version=f"%(prog)s {_get_version()}",
     )
     subparsers = parser.add_subparsers(dest="command", help="Available commands")
 


### PR DESCRIPTION
## Summary

Adds `--version` / `-V` flag to the `tribalmemory` CLI, resolving #112.

## Changes

### `src/tribalmemory/cli.py`
- Import `importlib.metadata.version` as `metadata_version`
- Add `_get_version()` helper that reads the installed package version via `importlib.metadata`, with a graceful fallback to `'unknown'` if metadata is unavailable
- Add `--version` / `-V` argument to the main argparse parser using `action='version'`

### `tests/test_cli.py`
- **`TestVersionFlag`** class with 4 tests (TDD: written before implementation):
  - `test_version_flag_exits_zero` — verifies exit code 0
  - `test_version_flag_prints_version` — verifies version string is printed
  - `test_version_matches_pyproject` — cross-checks against pyproject.toml
  - `test_version_fallback_when_metadata_unavailable` — verifies graceful fallback

## Testing

```
$ PYTHONPATH=src pytest tests/test_cli.py -v
48 passed
```

Closes #112