### PR TITLE
test: Improve benchmark test maintainability and documentation

### DIFF
--- a/tests/test_lazy_spacy_benchmark.py
+++ b/tests/test_lazy_spacy_benchmark.py
@@ -166,6 +166,7 @@ class TestLazySpacyBenchmark:
             f"eager={eager_time:.3f}s (speedup={speedup:.1f}x)"
         )
 
+    @pytest.mark.slow
     @pytest.mark.asyncio
     async def test_ingest_benchmark_100(
         self, tmp_path, mock_embedding_service
@@ -534,3 +535,143 @@ class TestLazySpacyBenchmark:
         print(
             f"  Design tradeoff: lazy trades graph richness for ~70x faster ingest"
         )
+
+    @pytest.mark.asyncio
+    async def test_graph_expansion_tradeoff_documentation(self, tmp_path):
+        """Document the design tradeoff between lazy and eager modes (Issue #127).
+
+        This test serves as living documentation of the lazy spaCy design decision:
+
+        **Lazy Mode (lazy_spacy=True):**
+        - Ingest: Regex-only entity extraction → ~70x faster with real embeddings
+        - Graph: Captures high-signal entities (services, tech, capitalized names)
+        - Tradeoff: Misses context-dependent entities that spaCy would detect
+
+        **Eager Mode (lazy_spacy=False):**
+        - Ingest: Full spaCy NER → richer entity graph, slower ingest
+        - Graph: Captures all entities including context-dependent ones
+        - Tradeoff: Ingest latency increases significantly
+
+        **Recommendation:** Use lazy mode for most workloads. The regex extractor
+        captures the most important entities while dramatically reducing ingest time.
+        Use eager mode only when entity graph richness is critical.
+        """
+        # Use higher-dimensional embeddings to better simulate real-world usage
+        embedding_service = MockEmbeddingService(embedding_dim=384)
+
+        # Entity-rich memories designed to highlight extraction differences
+        memories = [
+            "Sarah deployed auth-service v2.1 to production using Docker Compose",
+            "The api-gateway handles authentication via JWT tokens and Redis cache",
+            "John discussed the migration plan with the DevOps team at the office",
+            "PostgreSQL replication lag caused timeout errors in payment-service",
+            "Alice configured monitoring with Prometheus and Grafana dashboards",
+        ]
+
+        # === Lazy Mode ===
+        lazy_vector_store = MockVectorStore(embedding_service)
+        lazy_graph_store = GraphStore(str(tmp_path / "lazy_graph.db"))
+        lazy_service = TribalMemoryService(
+            instance_id="lazy-tradeoff",
+            embedding_service=embedding_service,
+            vector_store=lazy_vector_store,
+            graph_store=lazy_graph_store,
+            graph_enabled=True,
+            lazy_spacy=True,
+        )
+
+        for content in memories:
+            await lazy_service.remember(content)
+
+        # === Eager Mode ===
+        eager_vector_store = MockVectorStore(embedding_service)
+        eager_graph_store = GraphStore(str(tmp_path / "eager_graph.db"))
+        eager_service = TribalMemoryService(
+            instance_id="eager-tradeoff",
+            embedding_service=embedding_service,
+            vector_store=eager_vector_store,
+            graph_store=eager_graph_store,
+            graph_enabled=True,
+            lazy_spacy=False,
+        )
+
+        for content in memories:
+            await eager_service.remember(content)
+
+        # === Compare Entity Extraction ===
+        lazy_entities = lazy_graph_store._conn.execute(
+            "SELECT name FROM entities ORDER BY name"
+        ).fetchall()
+        eager_entities = eager_graph_store._conn.execute(
+            "SELECT name FROM entities ORDER BY name"
+        ).fetchall()
+
+        lazy_entity_names = {name for (name,) in lazy_entities}
+        eager_entity_names = {name for (name,) in eager_entities}
+
+        print(f"\n{'='*70}")
+        print(f"Graph Expansion Tradeoff Analysis (Issue #127)")
+        print(f"{'='*70}")
+        print(f"Memories ingested: {len(memories)}")
+        print(f"Embedding dimension: {embedding_service.embedding_dim}")
+        print()
+        print(f"Lazy mode entities ({len(lazy_entity_names)}):")
+        print(f"  {sorted(lazy_entity_names)}")
+        print()
+        print(f"Eager mode entities ({len(eager_entity_names)}):")
+        print(f"  {sorted(eager_entity_names)}")
+        print()
+
+        if SPACY_AVAILABLE:
+            only_in_eager = eager_entity_names - lazy_entity_names
+            only_in_lazy = lazy_entity_names - eager_entity_names
+            common = lazy_entity_names & eager_entity_names
+
+            print(f"Common entities: {len(common)}")
+            print(f"Only in eager (spaCy-detected): {len(only_in_eager)}")
+            if only_in_eager:
+                print(f"  {sorted(only_in_eager)}")
+            print(f"Only in lazy (regex-detected): {len(only_in_lazy)}")
+            if only_in_lazy:
+                print(f"  {sorted(only_in_lazy)}")
+            print()
+            print(f"Design decision: Lazy mode trades {len(only_in_eager)} "
+                  f"spaCy-detected entities for ~70x faster ingest")
+        else:
+            print(f"⚠ spaCy not installed — both modes use regex")
+            print(f"  Install spaCy to see the extraction difference:")
+            print(f"    pip install tribalmemory[spacy] && "
+                  f"python -m spacy download en_core_web_sm")
+
+        print(f"{'='*70}\n")
+
+        # === Test Recall with Graph Expansion ===
+        # Use min_relevance=0.0 to retrieve all memories regardless of similarity
+        lazy_results = await lazy_service.recall(
+            "authentication system", limit=10, min_relevance=0.0, graph_expansion=True
+        )
+        eager_results = await eager_service.recall(
+            "authentication system", limit=10, min_relevance=0.0, graph_expansion=True
+        )
+
+        print(f"Recall with graph expansion (min_relevance=0.0):")
+        print(f"  Lazy:  {len(lazy_results)} results")
+        print(f"  Eager: {len(eager_results)} results")
+
+        # === Assertions ===
+        # Both modes should extract some entities
+        assert len(lazy_entity_names) > 0, "Lazy mode should extract entities"
+        assert len(eager_entity_names) > 0, "Eager mode should extract entities"
+
+        if SPACY_AVAILABLE:
+            # With spaCy, eager should extract at least as many entities
+            assert len(eager_entity_names) >= len(lazy_entity_names), (
+                f"Eager mode should extract ≥ lazy entities: "
+                f"eager={len(eager_entity_names)}, lazy={len(lazy_entity_names)}"
+            )
+
+        # Both modes should successfully recall memories
+        assert len(lazy_results) > 0, "Lazy mode should return results"
+        assert len(eager_results) > 0, "Eager mode should return results"
+
+        print(f"✅ Graph expansion tradeoff documented and verified")

--- a/tests/test_spacy_benchmark.py
+++ b/tests/test_spacy_benchmark.py
@@ -23,6 +23,17 @@ from tribalmemory.services.memory import TribalMemoryService
 from tribalmemory.testing.mocks import MockEmbeddingService, MockVectorStore
 
 
+# --- Speedup thresholds (Issue #126) ---
+
+# Tolerance for lazy mode performance relative to eager mode.
+# Lazy ingest should not be significantly slower than eager.
+MAX_LAZY_SLOWDOWN_RATIO = 1.20  # 20% tolerance for timer noise
+
+# When spaCy is installed, lazy should be measurably faster.
+# Conservative threshold accounting for test variance.
+MAX_SPACY_LAZY_SLOWDOWN_RATIO = 1.10  # 10% tolerance with spaCy
+
+
 # --- Sample data ---
 
 SAMPLE_MEMORIES = [
@@ -213,13 +224,14 @@ class TestSpacyBenchmark:
         )
 
         # Lazy ingest should not be significantly slower than eager.
-        # 20% tolerance accounts for:
+        # Tolerance accounts for:
         # - Timer granularity on fast operations (sub-ms noise)
         # - GC pauses and OS scheduling jitter
         # - pytest fixture overhead variance between runs
-        assert lazy.ingest_total_ms <= eager.ingest_total_ms * 1.20, (
-            f"Lazy ingest ({lazy.ingest_total_ms:.2f}ms) was more than 20% "
-            f"slower than eager ({eager.ingest_total_ms:.2f}ms)"
+        assert lazy.ingest_total_ms <= eager.ingest_total_ms * MAX_LAZY_SLOWDOWN_RATIO, (
+            f"Lazy ingest ({lazy.ingest_total_ms:.2f}ms) was more than "
+            f"{(MAX_LAZY_SLOWDOWN_RATIO - 1) * 100:.0f}% slower than eager "
+            f"({eager.ingest_total_ms:.2f}ms)"
         )
 
     @pytest.mark.asyncio
@@ -249,6 +261,7 @@ class TestSpacyBenchmark:
                 f"{label} num_queries: expected {len(SAMPLE_QUERIES)}, got {result.num_queries}"
             )
 
+    @pytest.mark.slow
     @pytest.mark.asyncio
     async def test_benchmark_summary_table(
         self, tmp_path, mock_embedding_service, capsys
@@ -336,9 +349,9 @@ class TestSpacyBenchmark:
         # With spaCy, lazy ingest should be faster (regex-only vs regex+spaCy).
         # We just verify it's not slower — the speedup magnitude depends on
         # the machine and spaCy model loading overhead.
-        # 10% tolerance (tighter than mock test) because spaCy NER is the
+        # Tighter tolerance than mock test because spaCy NER is the
         # dominant cost, making the signal-to-noise ratio much higher.
-        assert lazy.ingest_total_ms <= eager.ingest_total_ms * 1.10, (
+        assert lazy.ingest_total_ms <= eager.ingest_total_ms * MAX_SPACY_LAZY_SLOWDOWN_RATIO, (
             f"With spaCy installed, lazy ingest ({lazy.ingest_total_ms:.2f}ms) "
             f"should not be slower than eager ({eager.ingest_total_ms:.2f}ms)"
         )


### PR DESCRIPTION
Closes #125
Closes #126
Closes #127

This PR enhances the benchmark test suite with three improvements:

## Issue #125: Add @pytest.mark.slow to benchmark tests ⏱️

Added `@pytest.mark.slow` decorator to expensive benchmark tests to enable faster test iteration:

- `test_benchmark_summary_table` (runs full benchmark twice)
- `test_ingest_benchmark_100` (100 memories)
- `test_comprehensive_benchmark` (200 memories, already had marker)

**Benefit:** Fast tests complete in ~25s, full suite in ~45s

**Usage:**
```bash
# Skip slow tests during development
pytest -m "not slow" tests/test_spacy_benchmark.py

# Run only slow tests for comprehensive benchmarking
pytest -m slow tests/
```

## Issue #126: Extract speedup thresholds to named constants 🔢

Replaced magic numbers (1.20, 1.10) with self-documenting named constants:

- `MAX_LAZY_SLOWDOWN_RATIO = 1.20` - General 20% tolerance for timer noise
- `MAX_SPACY_LAZY_SLOWDOWN_RATIO = 1.10` - Tighter 10% tolerance when spaCy is installed

**Benefit:** Improves maintainability and makes performance expectations explicit

## Issue #127: Test graph expansion differs between lazy/eager modes 📊

Added comprehensive test `test_graph_expansion_tradeoff_documentation` that serves as living documentation of the lazy spaCy design decision:

- Uses `MockEmbeddingService(embedding_dim=384)` for realistic simulation
- Uses `min_relevance=0.0` to retrieve all memories regardless of similarity
- Compares entity extraction between modes
- Documents the design tradeoff:
  - **Lazy mode:** regex extraction → ~70x faster ingest, fewer entities
  - **Eager mode:** spaCy NER → richer entity graph, slower ingest
- Prints detailed analysis showing which entities are captured by each mode

**Benefit:** New developers can understand the lazy spaCy tradeoff by reading the test output

## Testing

All existing tests pass:
```bash
# Full benchmark suite
PYTHONPATH=src pytest tests/test_spacy_benchmark.py tests/test_lazy_spacy_benchmark.py -x
# 13 passed in ~45s

# Fast tests only
pytest -m "not slow" tests/test_spacy_benchmark.py tests/test_lazy_spacy_benchmark.py
# 10 passed, 3 deselected in ~25s
```