### PR TITLE
feat: Dependency-parsed relationships (Closes #132)

### DIFF
--- a/src/tribalmemory/services/graph_store.py
+++ b/src/tribalmemory/services/graph_store.py
@@ -1316,8 +1316,9 @@ class DependencyRelationshipExtractor:
         """Match text span to a known entity name.
         
         Uses case-insensitive matching. Prefers exact matches, then checks
-        if text is contained within a multi-word entity name. Returns the
-        canonical entity name in original case.
+        if text appears as a complete word within a multi-word entity name
+        using word boundary matching to prevent false positives (e.g.,
+        "can" should NOT match "Glen Canyon Dam").
         
         Args:
             text: Text span from dependency parse.
@@ -1332,13 +1333,15 @@ class DependencyRelationshipExtractor:
         if text_lower in entity_map:
             return entity_map[text_lower]
         
-        # Check if text is a substring of a multi-word entity
-        # (e.g., "Dam" matches "glen canyon dam" → "Glen Canyon Dam")
+        # Check if text appears as a complete word within a multi-word entity.
+        # Uses word boundary regex to prevent false positives like
+        # "can" matching "Glen Canyon Dam" or "go" matching "Chicago".
         # Only match if text is shorter (avoid matching "New York City" to "New York")
+        pattern = re.compile(r'\b' + re.escape(text_lower) + r'\b')
         candidates = [
             (entity_lower, entity_original)
             for entity_lower, entity_original in entity_map.items()
-            if text_lower in entity_lower and len(text_lower) < len(entity_lower)
+            if len(text_lower) < len(entity_lower) and pattern.search(entity_lower)
         ]
         
         if len(candidates) == 1:

--- a/tests/test_dependency_relationships.py
+++ b/tests/test_dependency_relationships.py
@@ -668,3 +668,47 @@ class TestEdgeCases:
             if rel.relation_type == "uses":
                 # Should match the full entity name
                 assert "JavaScript" in {rel.source, rel.target}
+
+    def test_no_false_positive_substring_matching(self):
+        """Should NOT match 'can' to 'Glen Canyon Dam' or 'go' to 'Chicago'.
+        
+        Regression test for word boundary matching bug where simple substring
+        checks caused false positive entity matches.
+        """
+        extractor = DependencyRelationshipExtractor()
+        
+        import spacy
+        nlp = spacy.load("en_core_web_sm")
+        
+        # "can" should not match "Glen Canyon Dam"
+        doc = nlp("I can visit the park")
+        entities = [
+            Entity(name="Glen Canyon Dam", entity_type="place"),
+            Entity(name="Central Park", entity_type="place"),
+        ]
+        relationships = extractor.extract(doc, entities)
+        # Should not create a relationship with Glen Canyon Dam via "can"
+        for rel in relationships:
+            assert rel.source != "Glen Canyon Dam" or rel.target != "Glen Canyon Dam", \
+                f"False positive: 'can' matched 'Glen Canyon Dam' in relationship: {rel}"
+        
+        # "go" should not match "Chicago"
+        doc2 = nlp("I go to the store")
+        entities2 = [
+            Entity(name="Chicago", entity_type="place"),
+            Entity(name="The Store", entity_type="organization"),
+        ]
+        relationships2 = extractor.extract(doc2, entities2)
+        for rel in relationships2:
+            assert rel.source != "Chicago" and rel.target != "Chicago", \
+                f"False positive: 'go' matched 'Chicago' in relationship: {rel}"
+        
+        # "dam" should not match "Amsterdam"
+        doc3 = nlp("The dam was built last year")
+        entities3 = [
+            Entity(name="Amsterdam", entity_type="place"),
+        ]
+        relationships3 = extractor.extract(doc3, entities3)
+        for rel in relationships3:
+            assert rel.source != "Amsterdam" and rel.target != "Amsterdam", \
+                f"False positive: 'dam' matched 'Amsterdam' in relationship: {rel}"


### PR DESCRIPTION
## Summary
Implements Phase 4 of Entity Extraction v2: dependency-parsed relationships using spaCy's dependency parser.

## Changes
- **DependencyRelationshipExtractor class**: Uses spaCy dependency parser to extract subject-verb-object triples
- **Verb-to-relationship mapping**: Comprehensive mapping of common verbs to semantic relationship types (uses, lives, works, visited, met, prefers, purchased, etc.)
- **HybridEntityExtractor integration**: Dependency parsing enabled for personal extraction context
- **Edge case handling**:
  - Prepositional phrases ("lives in Denver")
  - Passive voice ("was recommended by Alice")
  - Compound subjects/objects ("John and Mary visited Paris")
  - Coordinated verbs ("works at Google and lives in Seattle")
  - Multi-word entities ("New York", "Glen Canyon Dam")
  - Pronoun filtering ("I", "he", "they" excluded)

## Testing
- 31 new comprehensive tests in `test_dependency_relationships.py`
- All new tests pass ✅
- All existing tests pass (222 passed)
- Covers basic SVO, prepositional relationships, passive voice, compound subjects, real conversation snippets, unicode, edge cases

## Quality Checklist
- [x] All new tests pass
- [x] All existing tests pass
- [x] Entities validated before relationship extraction
- [x] Relationships validated through RelationshipValidator
- [x] Backward compatibility maintained (extract() unchanged)

Closes #132