### PR TITLE
release: v0.7.1 — Fix broken tribal_store tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to TribalMemory will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.1] - 2026-02-07 ([PyPI](https://pypi.org/project/tribalmemory/0.7.1/))
+
+### Fixed
+- **`tribal_store` tool was completely broken** — Was sending `sourceType: "deliberate"` (invalid enum value), causing HTTP 422 on every call. Changed to `"user_explicit"`. Added regression test.
+
+---
+
 ## [0.7.0] - 2026-02-07 ([PyPI](https://pypi.org/project/tribalmemory/0.7.0/))
 
 ### Added

--- a/docs/specs/e2e-plugin-tests.md
+++ b/docs/specs/e2e-plugin-tests.md
@@ -68,6 +68,7 @@ tribal_store tests:
 - [ ] Store duplicate → verify dedup response (duplicate_of)
 - [ ] Store empty content → verify graceful error (not crash)
 - [ ] Store with invalid sourceType → verify 422 + error message (regression test for the "deliberate" bug)
+- [ ] Store with `"deliberate"` sourceType explicitly → verify it still fails with 422 (true e2e regression: sends the bad value to a real server, prevents re-introduction of the bug)
 - [ ] Store very long content (10KB+) → verify success
 - [ ] Verify stored memory retrievable via `/v1/recall`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ where = ["src"]
 
 [project]
 name = "tribalmemory"
-version = "0.7.0"
+version = "0.7.1"
 description = "Shared memory infrastructure for multi-instance AI agents"
 readme = "README.md"
 license = {text = "BSL-1.1"}

--- a/src/tribalmemory/__init__.py
+++ b/src/tribalmemory/__init__.py
@@ -1,3 +1,3 @@
 """Tribal Memory - Shared memory infrastructure for multi-instance AI agents."""
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"


### PR DESCRIPTION
Patch release: version bump + CHANGELOG for v0.7.1.

Fixes `tribal_store` sending invalid `sourceType: "deliberate"` → `"user_explicit"`.