### PR TITLE
feat: E2E test infrastructure + tribal_store tests (#144)

### DIFF
--- a/extensions/memory-tribal/tests/e2e/setup.ts
+++ b/extensions/memory-tribal/tests/e2e/setup.ts
@@ -71,7 +71,7 @@ async function findFreePort(): Promise<number> {
  */
 async function waitForHealth(
   baseUrl: string,
-  timeoutMs: number = 30000,
+  timeoutMs: number = parseInt(process.env.E2E_HEALTH_TIMEOUT_MS || "30000", 10),
 ): Promise<void> {
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
@@ -79,7 +79,7 @@ async function waitForHealth(
       const res = await fetch(`${baseUrl}/v1/health`);
       if (res.ok) {
         // Validate health response structure
-        const data = (await res.json()) as Record<string, unknown>;
+        const data = (await res.json()) as { status?: string };
         if (data.status === "ok") {
           return;
         }

--- a/extensions/memory-tribal/tests/e2e/tribal-store.test.ts
+++ b/extensions/memory-tribal/tests/e2e/tribal-store.test.ts
@@ -14,7 +14,18 @@ import {
   type TestEnvironment,
 } from "./setup";
 
+// 10KB+ tests server handling of payloads exceeding typical memory size
 const LARGE_CONTENT_SIZE = 10240;
+
+interface RecallResult {
+  memory: {
+    content: string;
+    tags: string[];
+    memory_id: string;
+  };
+  similarity_score: number;
+  retrieval_time_ms?: number;
+}
 
 describe("tribal_store E2E", () => {
   let env: TestEnvironment;
@@ -53,6 +64,7 @@ describe("tribal_store E2E", () => {
     });
     expect(storeRes.status).toBe(200);
     expect(storeRes.body.success).toBe(true);
+    const storedMemoryId = storeRes.body.memory_id as string;
 
     // Recall and verify tags + response structure
     const recallRes = await rawPost(env.baseUrl, "/v1/recall", {
@@ -65,10 +77,7 @@ describe("tribal_store E2E", () => {
     expect(recallRes.body.results).toBeDefined();
     expect(Array.isArray(recallRes.body.results)).toBe(true);
 
-    const results = recallRes.body.results as Array<{
-      memory: { content: string; tags: string[] };
-      similarity_score: number;
-    }>;
+    const results = recallRes.body.results as RecallResult[];
     
     // Each result should have required fields
     for (const result of results) {
@@ -81,8 +90,9 @@ describe("tribal_store E2E", () => {
       expect(result.similarity_score).toBeLessThanOrEqual(1);
     }
 
+    // Find our stored memory (improved test isolation)
     const match = results.find((r) =>
-      r.memory.content.includes("PostgreSQL"),
+      r.memory.memory_id === storedMemoryId || r.memory.content.includes("PostgreSQL"),
     );
     expect(match).toBeDefined();
     expect(match!.memory.tags).toEqual(expect.arrayContaining(tags));
@@ -146,6 +156,7 @@ describe("tribal_store E2E", () => {
   });
 
   it("should reject other invalid sourceType values with 422", async () => {
+    // Comprehensive test of various invalid types (deliberate tested above, included here for completeness)
     const invalidTypes = ["deliberate", "manual", "agent", "system", ""];
     for (const badType of invalidTypes) {
       const res = await rawPost(env.baseUrl, "/v1/remember", {
@@ -217,9 +228,7 @@ describe("tribal_store E2E", () => {
     });
     expect(recallRes.status).toBe(200);
 
-    const results = recallRes.body.results as Array<{
-      memory: { content: string };
-    }>;
+    const results = recallRes.body.results as RecallResult[];
     const found = results.some((r) =>
       r.memory.content.includes("blue-green"),
     );


### PR DESCRIPTION
## E2E Tests — Real Server, No Mocks

Adds the first E2E test suite for the memory-tribal plugin. Tests run against a **real TribalMemory server** — no HTTP mocking.

### Infrastructure (`tests/e2e/setup.ts`)
- Spawns `tribalmemory serve` on a random free port
- Fresh temporary database per test suite
- Health check polling before tests start
- Automatic cleanup (kill server + remove temp files)
- `rawPost()` helper for testing invalid payloads the client would reject
- `VALID_SOURCE_TYPES` constant + TypeScript `SourceType` union type

### Tests (`tests/e2e/tribal-store.test.ts`) — 12 tests
- ✅ Store memory → verify 200 + memory_id
- ✅ Store with tags → preserved on recall
- ✅ Store with context → preserved
- ✅ Duplicate detection
- ✅ Empty content → 422
- ✅ **`sourceType: "deliberate"` → 422** (regression for the shipped bug)
- ✅ Multiple invalid sourceType values → all 422
- ✅ All valid sourceType values → all accepted
- ✅ Long content (10KB+) → success
- ✅ Store then recall round-trip
- ✅ `VALID_SOURCE_TYPES` compile-time guard
- ✅ `TribalClient.remember()` integration

All 12 tests pass in 36 seconds.

Closes #144