### PR TITLE
fix: Address token auth review follow-ups (#168-#171)

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,0 +1,200 @@
+# Authentication
+
+TribalMemory supports bearer token authentication to protect your
+memory API from unauthorized access.
+
+## Quick Start
+
+```bash
+# Generate a token
+tribalmemory token generate
+
+# Start the server (token is loaded automatically)
+tribalmemory serve
+```
+
+The server reads the token from `~/.tribal-memory/.env` on startup.
+All non-public endpoints require the token in the `Authorization`
+header:
+
+```bash
+curl -H "Authorization: Bearer tm_abc123..." \
+  http://127.0.0.1:18790/v1/recall \
+  -d '{"query": "meeting notes"}'
+```
+
+## Token Management
+
+### Generate a Token
+
+```bash
+tribalmemory token generate
+```
+
+This creates a `tm_`-prefixed token with 256 bits of cryptographic
+entropy and saves it to `~/.tribal-memory/.env` with `600`
+permissions (owner read/write only).
+
+> **Important:** The full token is displayed only once at generation
+> time. Copy it immediately and store it securely.
+
+### Rotate a Token
+
+```bash
+tribalmemory token rotate
+```
+
+Generates a new token and replaces the old one. The server must be
+restarted to pick up the new token. Update all clients with the new
+token after rotation.
+
+### View Current Token
+
+```bash
+tribalmemory token show
+```
+
+Displays a masked version of the token (`tm_...last8chars`) for
+verification. The full token is never shown after initial generation.
+
+## Token Storage
+
+Tokens are stored in **`~/.tribal-memory/.env`** as:
+
+```
+TRIBAL_MEMORY_API_TOKEN=tm_<64 hex chars>
+```
+
+The file is created with `600` permissions (owner read/write only).
+Other environment variables in the file are preserved during token
+operations.
+
+### Environment Variable Override
+
+Set `TRIBAL_MEMORY_API_TOKEN` as an environment variable to override
+the file-based token. This is useful for containerized deployments
+(12-factor app pattern):
+
+```bash
+export TRIBAL_MEMORY_API_TOKEN=tm_abc123...
+tribalmemory serve
+```
+
+The server logs which source the token was loaded from (environment
+variable or file).
+
+## Legacy Mode
+
+If no token is configured, the server runs in **legacy mode**:
+
+- All requests are allowed without authentication
+- A warning is logged on startup
+- This preserves backward compatibility for existing deployments
+
+To secure your instance, run `tribalmemory token generate`.
+
+## Public Paths
+
+The following paths never require authentication:
+
+| Path | Purpose |
+|------|---------|
+| `/` | Root endpoint |
+| `/health` | Health check |
+| `/v1/health` | Versioned health check |
+| `/docs` | Swagger UI |
+| `/redoc` | ReDoc UI |
+| `/openapi.json` | OpenAPI schema |
+
+`OPTIONS` requests are also allowed without auth for CORS preflight.
+
+## Rate Limiting
+
+Failed authentication attempts are rate-limited per client IP:
+
+- **Threshold:** 10 failed attempts
+- **Cooldown:** 60 seconds
+- **Scope:** Per IP address, in-memory
+
+After 10 failures from the same IP, the server returns `429 Too Many
+Requests` for 60 seconds. A successful authentication clears the
+failure count for that IP.
+
+Rate limit state is in-memory only and resets on server restart.
+The server tracks up to 10,000 unique IPs to prevent unbounded
+memory growth.
+
+## HTTPS / Transport Security
+
+TribalMemory binds to `127.0.0.1` by default, so the API is only
+accessible from the local machine. For remote access, **always use
+encrypted transport**.
+
+### Recommended: Tailscale Serve
+
+[Tailscale Serve](https://tailscale.com/kb/1242/tailscale-serve)
+provides automatic HTTPS with no configuration:
+
+```bash
+# Expose TribalMemory over Tailscale with HTTPS
+tailscale serve https / http://127.0.0.1:18790
+```
+
+This gives you:
+- Automatic TLS certificates (via Let's Encrypt)
+- Access only from your Tailscale network
+- No port forwarding or firewall changes needed
+
+### Alternative: Reverse Proxy
+
+Use nginx or Caddy as a reverse proxy with TLS termination:
+
+```nginx
+server {
+    listen 443 ssl;
+    server_name memory.example.com;
+
+    ssl_certificate /path/to/cert.pem;
+    ssl_certificate_key /path/to/key.pem;
+
+    location / {
+        proxy_pass http://127.0.0.1:18790;
+        proxy_set_header Authorization $http_authorization;
+    }
+}
+```
+
+> **Warning:** Never expose TribalMemory directly on a public
+> network without TLS. Bearer tokens sent over plain HTTP can be
+> intercepted.
+
+## MCP Client Configuration
+
+When using TribalMemory as an MCP server (Claude Code, Codex), the
+token is passed via environment variables in the MCP config:
+
+```json
+{
+  "mcpServers": {
+    "tribal-memory": {
+      "command": "tribalmemory-mcp",
+      "env": {
+        "TRIBAL_MEMORY_API_TOKEN": "tm_abc123..."
+      }
+    }
+  }
+}
+```
+
+For HTTP-based MCP clients, include the token in the server URL
+or pass it as a header per your client's configuration.
+
+## Security Properties
+
+- **Token entropy:** 256 bits (cryptographically secure via
+  `secrets.token_hex`)
+- **Comparison:** Constant-time via `hmac.compare_digest` (prevents
+  timing attacks)
+- **Storage:** File permissions `600` (owner-only access)
+- **Prefix:** `tm_` for easy identification in logs and configs
+- **Audit:** Successful and failed auth attempts are logged

--- a/src/tribalmemory/cli.py
+++ b/src/tribalmemory/cli.py
@@ -283,7 +283,10 @@ def cmd_init(args: argparse.Namespace) -> int:
         if mcp_command == "tribalmemory-mcp":
             print("⚠️  Could not find tribalmemory-mcp on PATH or in ~/.local/bin")
             print("   Claude Desktop needs the absolute path to the binary.")
-            print("   After installing with pipx/uv, run: tribalmemory init --claude-desktop --force")
+            print(
+                "   After installing with pipx/uv, run: "
+                "tribalmemory init --claude-desktop --force"
+            )
             print()
 
     # Create config directory
@@ -499,7 +502,10 @@ def _resolve_mcp_command() -> str:
 def _get_claude_desktop_config_path() -> Path:
     """Get the platform-appropriate Claude Desktop config path."""
     if sys.platform == "darwin":
-        return Path.home() / "Library" / "Application Support" / "Claude" / "claude_desktop_config.json"
+        return (
+            Path.home() / "Library" / "Application Support"
+            / "Claude" / "claude_desktop_config.json"
+        )
     elif sys.platform == "win32":
         return Path.home() / "AppData" / "Roaming" / "Claude" / "claude_desktop_config.json"
     else:

--- a/src/tribalmemory/server/app.py
+++ b/src/tribalmemory/server/app.py
@@ -99,7 +99,8 @@ async def lifespan(app: FastAPI):
 
     search_mode = "hybrid (vector + BM25)" if config.search.hybrid_enabled else "vector-only"
     logger.info(f"Memory service initialized (db: {config.db.path}, search: {search_mode})")
-    logger.info(f"Session store initialized (retention: {config.server.session_retention_days} days)")
+    retention = config.server.session_retention_days
+    logger.info(f"Session store initialized (retention: {retention} days)")
 
     # Start background session cleanup task
     cleanup_task = asyncio.create_task(
@@ -137,7 +138,12 @@ async def _session_cleanup_loop(
             await asyncio.sleep(cleanup_interval)
             deleted = await session_store.cleanup(retention_days=retention_days)
             if deleted > 0:
-                logger.info(f"Session cleanup: deleted {deleted} expired chunks (retention: {retention_days} days)")
+                logger.info(
+                    "Session cleanup: deleted %d expired chunks "
+                    "(retention: %d days)",
+                    deleted,
+                    retention_days,
+                )
         except asyncio.CancelledError:
             raise
         except Exception:
@@ -170,10 +176,12 @@ def create_app(config: Optional[TribalMemoryConfig] = None) -> FastAPI:
     # Precedence: environment variable > .env file > no token (legacy mode)
     api_token = os.environ.get("TRIBAL_MEMORY_API_TOKEN") or load_token()
     if api_token:
-        logger.info(
-            "API token loaded from %s",
-            "environment variable" if os.environ.get("TRIBAL_MEMORY_API_TOKEN") else "~/.tribal-memory/.env",
+        source = (
+            "environment variable"
+            if os.environ.get("TRIBAL_MEMORY_API_TOKEN")
+            else "~/.tribal-memory/.env"
         )
+        logger.info("API token loaded from %s", source)
     app.add_middleware(TokenAuthMiddleware, token=api_token)
 
     # CORS middleware (localhost only)

--- a/src/tribalmemory/server/auth.py
+++ b/src/tribalmemory/server/auth.py
@@ -3,12 +3,13 @@
 Security properties:
 - 32-byte random token (256 bits entropy), prefixed with 'tm_'
 - Constant-time comparison (no timing attacks)
-- Rate limiting on failed auth attempts
+- Rate limiting on failed auth attempts (persisted to disk)
 - Token stored in ~/.tribal-memory/.env with 600 permissions
 """
 
 import hashlib
 import hmac
+import json
 import logging
 import os
 import secrets
@@ -105,6 +106,89 @@ def load_token(env_path: Optional[Path] = None) -> Optional[str]:
     return None
 
 
+def _default_rate_limit_path() -> Path:
+    """Return default path for rate limit state persistence."""
+    return Path("~/.tribal-memory/rate-limits.json").expanduser()
+
+
+def save_rate_limit_state(
+    failure_count: dict[str, int],
+    cooldown_until: dict[str, float],
+    path: Optional[Path] = None,
+) -> None:
+    """Persist rate limit state to disk.
+
+    Only saves IPs that are currently in cooldown to avoid
+    persisting stale data.
+
+    Args:
+        failure_count: Per-IP failure counts.
+        cooldown_until: Per-IP cooldown expiry timestamps.
+        path: File path. Defaults to ~/.tribal-memory/rate-limits.json.
+    """
+    if path is None:
+        path = _default_rate_limit_path()
+
+    now = time.time()
+    # Only persist IPs with active cooldowns
+    active: dict[str, dict] = {}
+    for ip, until in cooldown_until.items():
+        if until > now:
+            active[ip] = {
+                "failures": failure_count.get(ip, 0),
+                "cooldown_until": until,
+            }
+
+    if not active:
+        # Remove file if no active cooldowns
+        if path.exists():
+            path.unlink()
+        return
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(active, f)
+    os.chmod(path, 0o600)
+
+
+def load_rate_limit_state(
+    path: Optional[Path] = None,
+) -> tuple[dict[str, int], dict[str, float]]:
+    """Load rate limit state from disk.
+
+    Returns only entries with active (non-expired) cooldowns.
+
+    Args:
+        path: File path. Defaults to ~/.tribal-memory/rate-limits.json.
+
+    Returns:
+        Tuple of (failure_count, cooldown_until) dicts.
+    """
+    if path is None:
+        path = _default_rate_limit_path()
+
+    failure_count: dict[str, int] = {}
+    cooldown_until: dict[str, float] = {}
+
+    if not path.exists():
+        return failure_count, cooldown_until
+
+    try:
+        with open(path) as f:
+            data = json.load(f)
+
+        now = time.time()
+        for ip, entry in data.items():
+            until = entry.get("cooldown_until", 0)
+            if until > now:
+                failure_count[ip] = entry.get("failures", 0)
+                cooldown_until[ip] = until
+    except (json.JSONDecodeError, OSError) as e:
+        logger.warning("Failed to load rate limit state: %s", e)
+
+    return failure_count, cooldown_until
+
+
 def _constant_time_compare(a: str, b: str) -> bool:
     """Compare two strings in constant time to prevent timing attacks."""
     return hmac.compare_digest(a.encode("utf-8"), b.encode("utf-8"))
@@ -132,12 +216,26 @@ class TokenAuthMiddleware(BaseHTTPMiddleware):
         "/",
     })
 
-    def __init__(self, app, token: Optional[str] = None):
+    def __init__(
+        self,
+        app,
+        token: Optional[str] = None,
+        rate_limit_path: Optional[Path] = None,
+    ):
         super().__init__(app)
         self.token = token
-        self._failure_count: dict[str, int] = {}
-        self._cooldown_until: dict[str, float] = {}
+        self._rate_limit_path = rate_limit_path
         self._max_tracked_ips = MAX_TRACKED_IPS
+
+        # Load persisted rate limit state
+        self._failure_count, self._cooldown_until = (
+            load_rate_limit_state(rate_limit_path)
+        )
+        if self._failure_count:
+            logger.info(
+                "Loaded %d rate-limited IPs from disk",
+                len(self._failure_count),
+            )
 
         if not token:
             logger.warning(
@@ -165,7 +263,9 @@ class TokenAuthMiddleware(BaseHTTPMiddleware):
     def _record_failure(self, client_ip: str) -> None:
         """Record a failed auth attempt and apply rate limiting if needed."""
         # Evict oldest entry if tracking too many IPs (memory safety)
-        if len(self._failure_count) >= self._max_tracked_ips and client_ip not in self._failure_count:
+        at_capacity = len(self._failure_count) >= self._max_tracked_ips
+        is_new_ip = client_ip not in self._failure_count
+        if at_capacity and is_new_ip:
             oldest_ip = next(iter(self._failure_count))
             self._failure_count.pop(oldest_ip, None)
             self._cooldown_until.pop(oldest_ip, None)
@@ -174,13 +274,21 @@ class TokenAuthMiddleware(BaseHTTPMiddleware):
         self._failure_count[client_ip] = count
 
         if count >= MAX_FAILURES:
-            self._cooldown_until[client_ip] = time.time() + COOLDOWN_SECONDS
+            self._cooldown_until[client_ip] = (
+                time.time() + COOLDOWN_SECONDS
+            )
             logger.warning(
                 "Rate limit triggered for %s (%d failures). "
                 "Cooldown for %ds.",
                 client_ip,
                 count,
                 COOLDOWN_SECONDS,
+            )
+            # Persist to disk on cooldown trigger
+            save_rate_limit_state(
+                self._failure_count,
+                self._cooldown_until,
+                self._rate_limit_path,
             )
 
     def _clear_failures(self, client_ip: str) -> None:
@@ -225,7 +333,10 @@ class TokenAuthMiddleware(BaseHTTPMiddleware):
             self._record_failure(client_ip)
             return JSONResponse(
                 status_code=401,
-                content={"error": "Missing API token. Include 'Authorization: Bearer <token>' header."},
+                content={
+                    "error": "Missing API token. "
+                    "Include 'Authorization: Bearer <token>' header."
+                },
                 headers={"WWW-Authenticate": "Bearer"},
             )
 
@@ -239,4 +350,10 @@ class TokenAuthMiddleware(BaseHTTPMiddleware):
 
         # Auth success
         self._clear_failures(client_ip)
+        logger.info(
+            "Auth success: %s %s from %s",
+            request.method,
+            request.url.path,
+            client_ip,
+        )
         return await call_next(request)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -16,7 +16,9 @@ from tribalmemory.server.auth import (
     TokenAuthMiddleware,
     _constant_time_compare,
     generate_token,
+    load_rate_limit_state,
     load_token,
+    save_rate_limit_state,
     save_token,
 )
 
@@ -115,10 +117,20 @@ class TestConstantTimeCompare:
 # ---------------------------------------------------------------------------
 
 
-def _create_test_app(token=None):
+def _create_test_app(token=None, rate_limit_path=None):
     """Create a minimal FastAPI app with auth middleware for testing."""
+    import tempfile
     app = FastAPI()
-    app.add_middleware(TokenAuthMiddleware, token=token)
+    # Use isolated rate limit path to prevent test state leaking
+    if rate_limit_path is None:
+        rate_limit_path = Path(
+            tempfile.mkdtemp()
+        ) / "rate-limits.json"
+    app.add_middleware(
+        TokenAuthMiddleware,
+        token=token,
+        rate_limit_path=rate_limit_path,
+    )
 
     @app.get("/health")
     async def health():
@@ -342,3 +354,204 @@ class TestAuthMiddleware:
         from tribalmemory.server.auth import MAX_TRACKED_IPS
         assert MAX_TRACKED_IPS > 0
         assert MAX_TRACKED_IPS <= 100000
+
+
+# ---------------------------------------------------------------------------
+# Rate limit persistence
+# ---------------------------------------------------------------------------
+
+
+class TestRateLimitPersistence:
+    """Tests for rate limit state persistence to disk."""
+
+    def test_save_and_load_round_trip(self, tmp_path):
+        """Persisted rate limit state survives save/load cycle."""
+        path = tmp_path / "rate-limits.json"
+        future = time.time() + 3600  # 1 hour from now
+
+        save_rate_limit_state(
+            {"1.2.3.4": 10, "5.6.7.8": 5},
+            {"1.2.3.4": future, "5.6.7.8": future},
+            path,
+        )
+
+        failures, cooldowns = load_rate_limit_state(path)
+        assert failures["1.2.3.4"] == 10
+        assert failures["5.6.7.8"] == 5
+        assert cooldowns["1.2.3.4"] == future
+        assert cooldowns["5.6.7.8"] == future
+
+    def test_expired_cooldowns_not_loaded(self, tmp_path):
+        """Expired cooldowns are filtered out on load."""
+        path = tmp_path / "rate-limits.json"
+        past = time.time() - 100  # already expired
+        future = time.time() + 3600
+
+        save_rate_limit_state(
+            {"expired": 10, "active": 10},
+            {"expired": past, "active": future},
+            path,
+        )
+
+        # Re-write to include expired entry (save filters it out,
+        # so we write directly for this test)
+        import json
+        with open(path, "w") as f:
+            json.dump({
+                "expired_ip": {
+                    "failures": 10,
+                    "cooldown_until": past,
+                },
+                "active_ip": {
+                    "failures": 10,
+                    "cooldown_until": future,
+                },
+            }, f)
+
+        failures, cooldowns = load_rate_limit_state(path)
+        assert "expired_ip" not in failures
+        assert "active_ip" in failures
+        assert failures["active_ip"] == 10
+
+    def test_nonexistent_file_returns_empty(self, tmp_path):
+        """Loading from nonexistent file returns empty dicts."""
+        path = tmp_path / "nonexistent.json"
+        failures, cooldowns = load_rate_limit_state(path)
+        assert failures == {}
+        assert cooldowns == {}
+
+    def test_corrupted_file_returns_empty(self, tmp_path):
+        """Corrupted JSON file returns empty dicts (graceful)."""
+        path = tmp_path / "rate-limits.json"
+        with open(path, "w") as f:
+            f.write("not valid json{{{")
+
+        failures, cooldowns = load_rate_limit_state(path)
+        assert failures == {}
+        assert cooldowns == {}
+
+    def test_save_removes_file_when_no_active(self, tmp_path):
+        """File is cleaned up when no active cooldowns exist."""
+        path = tmp_path / "rate-limits.json"
+        past = time.time() - 100
+
+        # First create the file with active entry
+        future = time.time() + 3600
+        save_rate_limit_state(
+            {"1.2.3.4": 10},
+            {"1.2.3.4": future},
+            path,
+        )
+        assert path.exists()
+
+        # Now save with only expired entries
+        save_rate_limit_state(
+            {"1.2.3.4": 10},
+            {"1.2.3.4": past},
+            path,
+        )
+        assert not path.exists()
+
+    def test_save_sets_secure_permissions(self, tmp_path):
+        """Rate limit file should have 600 permissions."""
+        path = tmp_path / "rate-limits.json"
+        future = time.time() + 3600
+
+        save_rate_limit_state(
+            {"1.2.3.4": 10},
+            {"1.2.3.4": future},
+            path,
+        )
+
+        perms = oct(path.stat().st_mode)[-3:]
+        assert perms == "600"
+
+    def test_middleware_loads_persisted_state(self, tmp_path):
+        """Middleware picks up persisted rate limits on init."""
+        path = tmp_path / "rate-limits.json"
+        future = time.time() + 3600
+
+        # Persist a cooldown for testclient's IP
+        save_rate_limit_state(
+            {"testclient": MAX_FAILURES},
+            {"testclient": future},
+            path,
+        )
+
+        # Create app with the persisted state
+        app = _create_test_app(
+            token="tm_secret",
+            rate_limit_path=path,
+        )
+        client = TestClient(app)
+
+        # Should be immediately rate-limited
+        response = client.get(
+            "/v1/stats",
+            headers={"Authorization": "Bearer tm_secret"},
+        )
+        assert response.status_code == 429
+
+    def test_middleware_persists_on_cooldown(self, tmp_path):
+        """Middleware writes state to disk when cooldown triggers."""
+        path = tmp_path / "rate-limits.json"
+        app = _create_test_app(
+            token="tm_secret",
+            rate_limit_path=path,
+        )
+        client = TestClient(app)
+
+        assert not path.exists()
+
+        # Trigger rate limiting
+        for _ in range(MAX_FAILURES):
+            client.get(
+                "/v1/stats",
+                headers={"Authorization": "Bearer tm_wrong"},
+            )
+
+        # State should be persisted
+        assert path.exists()
+        failures, cooldowns = load_rate_limit_state(path)
+        assert len(failures) > 0
+
+
+# ---------------------------------------------------------------------------
+# Audit logging
+# ---------------------------------------------------------------------------
+
+
+class TestAuditLogging:
+    """Tests for auth audit logging."""
+
+    def test_successful_auth_logged(self, tmp_path, caplog):
+        """Successful authentication should be logged at INFO."""
+        import logging
+        with caplog.at_level(logging.INFO, logger="tribalmemory.auth"):
+            app = _create_test_app(token="tm_secret")
+            client = TestClient(app)
+            client.get(
+                "/v1/stats",
+                headers={"Authorization": "Bearer tm_secret"},
+            )
+
+        assert any(
+            "Auth success" in r.message and "/v1/stats" in r.message
+            for r in caplog.records
+        )
+
+    def test_failed_auth_not_logged_as_success(self, tmp_path, caplog):
+        """Failed auth should NOT produce success log."""
+        import logging
+        with caplog.at_level(logging.INFO, logger="tribalmemory.auth"):
+            app = _create_test_app(token="tm_secret")
+            client = TestClient(app)
+            client.get(
+                "/v1/stats",
+                headers={"Authorization": "Bearer tm_wrong"},
+            )
+
+        assert not any(
+            "Auth success" in r.message
+            for r in caplog.records
+        )


### PR DESCRIPTION
Addresses all 4 review follow-ups from PR #167:

## Changes

### #168 — Fix line length violations
- `auth.py`: Split rate limit capacity check and error message into multiple lines
- `cli.py`: Split long print statement and Path construction
- `app.py`: Fixed logger format strings exceeding 100 chars
- Zero lines > 100 chars remaining in changed files

### #169 — Authentication documentation
- New `docs/authentication.md` with:
  - Token generation/rotation/show guide
  - Environment variable vs file storage
  - HTTPS recommendations (Tailscale Serve, reverse proxy)
  - Rate limiting behavior
  - Legacy mode explanation
  - MCP client configuration

### #170 — Audit logging for successful auth
- Added `logger.info()` for successful auth attempts (method, path, IP)
- Failed auth continues to log at WARNING level

### #171 — Persistent rate limiting
- Rate limit state persisted to `~/.tribal-memory/rate-limits.json` (600 perms)
- Loaded on middleware startup, saved on cooldown trigger
- Expired entries auto-cleaned on load
- File removed when no active cooldowns exist
- Graceful handling of corrupted JSON files

## Tests
- 10 new tests: 8 rate limit persistence + 2 audit logging
- **40 total auth tests passing**

Closes #168, closes #169, closes #170, closes #171