### PR TITLE
Episode Memories Phase 3: Summarization & remember() Integration

### DIFF
--- a/src/tribalmemory/services/episode_detector.py
+++ b/src/tribalmemory/services/episode_detector.py
@@ -39,6 +39,7 @@ class EpisodeConfig:
         max_active_episodes: Maximum concurrent active episodes.
         summarizer_model: LLM model for summary generation.
         summarizer_provider: LLM provider ("openai", "anthropic", "ollama").
+        summarizer_temperature: Temperature for summary generation (0.0-2.0).
         full_regen_interval: Full summary regeneration every N memories.
         max_llm_calls_per_memory: Max LLM calls per remember() invocation.
         monthly_cost_ceiling: Pause episode processing if monthly cost exceeded.
@@ -50,6 +51,7 @@ class EpisodeConfig:
     max_active_episodes: int = 20
     summarizer_model: str = "gpt-4o-mini"
     summarizer_provider: str = "openai"  # "openai", "anthropic", "ollama"
+    summarizer_temperature: float = 0.3
     full_regen_interval: int = 10
     max_llm_calls_per_memory: int = 2
     monthly_cost_ceiling: float = 5.0

--- a/src/tribalmemory/services/episode_summarizer.py
+++ b/src/tribalmemory/services/episode_summarizer.py
@@ -23,6 +23,18 @@ from .episode_store import Episode, EpisodeStore
 logger = logging.getLogger(__name__)
 
 
+def _format_id(id_: Optional[str]) -> str:
+    """Format ID for logging (first 8 chars or 'None').
+    
+    Args:
+        id_: ID string to format.
+    
+    Returns:
+        First 8 characters of ID, or 'None' if ID is None.
+    """
+    return id_[:8] if id_ else "None"
+
+
 class EpisodeSummarizer:
     """Generate and maintain episode summaries.
     
@@ -169,15 +181,25 @@ Status: <status>"""
             
             logger.info(
                 "Updated summary for episode %s (%d new memories)",
-                episode_id[:8],
+                _format_id(episode_id),
                 len(unsummarized_ids),
             )
         
-        except Exception as e:
+        except (ValueError, TypeError, AttributeError) as e:
+            # Log with traceback for debugging
             logger.error(
                 "Failed to update summary for episode %s: %s",
-                episode_id[:8],
+                episode_id[:8] if episode_id else "None",
                 e,
+                exc_info=True,
+            )
+        except Exception as e:
+            # Catch unexpected errors but log with traceback
+            logger.error(
+                "Unexpected error updating summary for episode %s: %s",
+                episode_id[:8] if episode_id else "None",
+                e,
+                exc_info=True,
             )
     
     async def _progressive_update(
@@ -202,7 +224,7 @@ Status: <status>"""
                 new_memories.append(memory.content)
         
         if not new_memories:
-            return episode.summary
+            return episode.summary or ""
         
         # Build prompt
         prompt = self.PROGRESSIVE_PROMPT.format(
@@ -210,8 +232,10 @@ Status: <status>"""
             new_memories="\n".join(f"- {m}" for m in new_memories),
         )
         
-        # Call LLM
-        summary = await self.llm_client.complete(prompt, temperature=0.3)
+        # Call LLM with configured temperature
+        summary = await self.llm_client.complete(
+            prompt, temperature=self.config.summarizer_temperature
+        )
         return summary.strip()
     
     async def _full_regeneration(self, episode: Episode) -> str:
@@ -238,21 +262,18 @@ Status: <status>"""
                 all_memories.append(f"[{timestamp}] {memory.content}")
         
         if not all_memories:
-            return episode.summary
-        
-        # Build date range
-        date_range = self._format_date_range(episode)
+            return episode.summary or ""
         
         # Build prompt
         prompt = self.FULL_REGEN_PROMPT.format(
             title=episode.title,
             all_memories="\n".join(all_memories),
-            date_range=date_range,
-            status=episode.status,
         )
         
-        # Call LLM
-        summary = await self.llm_client.complete(prompt, temperature=0.3)
+        # Call LLM with configured temperature
+        summary = await self.llm_client.complete(
+            prompt, temperature=self.config.summarizer_temperature
+        )
         return summary.strip()
     
     async def _store_summary_memory(
@@ -311,12 +332,9 @@ Status: <status>"""
             result = await self.vector_store.store(summary_memory)
         
         if not result.success:
-            logger.error(
-                "Failed to store summary memory: %s",
-                result.error,
-            )
-            # Return existing ID or generate new one
-            return episode.summary_memory_id or str(uuid.uuid4())
+            error_msg = f"Failed to store summary memory: {result.error}"
+            logger.error(error_msg)
+            raise RuntimeError(error_msg)
         
         return result.memory_id
     
@@ -362,14 +380,15 @@ Status: <status>"""
                     
                     logger.info(
                         "Closed stale episode %s with final summary",
-                        episode_id[:8],
+                        _format_id(episode_id),
                     )
             
             except Exception as e:
                 logger.error(
                     "Failed to generate final summary for episode %s: %s",
-                    episode_id[:8],
+                    _format_id(episode_id),
                     e,
+                    exc_info=True,
                 )
         
         return stale_ids

--- a/src/tribalmemory/services/memory.py
+++ b/src/tribalmemory/services/memory.py
@@ -6,8 +6,12 @@ import os
 import re
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 import uuid
+
+if TYPE_CHECKING:
+    from .episode_detector import EpisodeDetector
+    from .episode_summarizer import EpisodeSummarizer
 
 from ..interfaces import (
     IMemoryService,

--- a/tests/test_episode_summarizer.py
+++ b/tests/test_episode_summarizer.py
@@ -3,7 +3,6 @@
 Tests progressive summarization, full regeneration, and integration with the remember() flow.
 """
 
-import json
 import pytest
 from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, Mock, patch
@@ -68,7 +67,7 @@ def mock_llm_client():
     return client
 
 
-@pytest.fixture
+@pytest.fixture(scope="function")
 def episode_store(tmp_path):
     """Episode store with temporary database."""
     db_path = tmp_path / "test_episodes.db"
@@ -501,7 +500,7 @@ async def test_llm_failure_handled_gracefully(summarizer, episode_store, mock_ve
 
 @pytest.mark.asyncio
 async def test_vector_store_failure_handled(summarizer, episode_store, mock_vector_store):
-    """Test vector store failure is handled gracefully."""
+    """Test vector store failure is handled gracefully (logged but episode not updated)."""
     episode = episode_store.create_episode("Test")
     memory_id = "mem-1"
     episode_store.add_memory(episode.id, memory_id)
@@ -519,12 +518,12 @@ async def test_vector_store_failure_handled(summarizer, episode_store, mock_vect
         return_value=StoreResult(success=False, error="Storage failed")
     )
     
-    # Should not raise exception
+    # Should not raise exception (caught in outer try/except)
     await summarizer.update_summary(episode.id)
     
-    # Episode summary should still be updated (best effort)
+    # Episode summary should NOT be updated when storage fails (prevents data loss)
     updated_episode = episode_store.get_episode(episode.id)
-    assert updated_episode.summary == "Summary"
+    assert updated_episode.summary == ""  # Still empty due to storage failure
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Phase 3 of Episode Memories (#190).

Adds EpisodeSummarizer with progressive and full regeneration, integrates episode detection + summarization into remember() flow, and adds auto-close for stale episodes.

Built on Phase 1 (#192) and Phase 2 (#193).

## Changes
- EpisodeSummarizer class (progressive + full regen)
- Summary stored as MemoryEntry (surfaces in recall automatically)
- remember() hook: detect → summarize (non-blocking)
- Stale episode auto-close with final summary
- 24 tests with mocked LLM/vector store

Part of Episode Memories epic (#190)