### PR TITLE
fix: bump version strings to 0.9.0

### DIFF
--- a/src/tribalmemory/__init__.py
+++ b/src/tribalmemory/__init__.py
@@ -1,3 +1,3 @@
 """Tribal Memory - Shared memory infrastructure for multi-instance AI agents."""
 
-__version__ = "0.7.1"
+__version__ = "0.9.0"

--- a/src/tribalmemory/server/app.py
+++ b/src/tribalmemory/server/app.py
@@ -11,6 +11,7 @@ import uvicorn
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from tribalmemory import __version__
 from ..services import create_memory_service, TribalMemoryService
 from ..services.session_store import (
     SessionStore,
@@ -224,7 +225,7 @@ def create_app(config: Optional[TribalMemoryConfig] = None) -> FastAPI:
     app = FastAPI(
         title="Tribal Memory",
         description="Long-term memory service for AI agents with provenance tracking",
-        version="0.1.0",
+        version=__version__,
         lifespan=lifespan,
     )
 
@@ -290,7 +291,7 @@ def create_app(config: Optional[TribalMemoryConfig] = None) -> FastAPI:
     async def root():
         return {
             "service": "tribal-memory",
-            "version": "0.1.0",
+            "version": __version__,
             "docs": "/docs",
             "graph": "/graph",
         }

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,56 @@
+"""Tests for version string consistency."""
+
+import re
+import pytest
+
+
+def test_version_format():
+    """Ensure version follows semantic versioning."""
+    from tribalmemory import __version__
+    
+    # Should match semver pattern (e.g., "0.9.0", "1.2.3", "2.0.0-beta")
+    semver_pattern = r'^\d+\.\d+\.\d+(-[a-zA-Z0-9.-]+)?$'
+    assert re.match(semver_pattern, __version__), \
+        f"Version '{__version__}' does not match semver pattern"
+
+
+def test_version_not_stale():
+    """Ensure version is not one of the known stale values."""
+    from tribalmemory import __version__
+    
+    stale_versions = ["0.7.1", "0.1.0"]
+    assert __version__ not in stale_versions, \
+        f"Version '{__version__}' is stale (matches one of {stale_versions})"
+
+
+def test_server_uses_package_version():
+    """Ensure server app uses the package version, not hardcoded."""
+    from tribalmemory import __version__
+    from tribalmemory.server.app import create_app
+    
+    app = create_app()
+    
+    # FastAPI app should use package version
+    assert app.version == __version__, \
+        f"FastAPI app version '{app.version}' doesn't match package version '{__version__}'"
+
+
+@pytest.mark.asyncio
+async def test_root_endpoint_version():
+    """Ensure root endpoint returns correct version."""
+    from tribalmemory import __version__
+    from tribalmemory.server.app import create_app
+    from httpx import AsyncClient, ASGITransport
+    
+    app = create_app()
+    
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test"
+    ) as client:
+        response = await client.get("/")
+        assert response.status_code == 200
+        data = response.json()
+        assert "version" in data
+        assert data["version"] == __version__, \
+            f"Root endpoint version '{data['version']}' doesn't match package version '{__version__}'"


### PR DESCRIPTION
## Problem
Two version strings were stale:
1. `src/tribalmemory/__init__.py` had `__version__ = "0.7.1"` instead of `"0.9.0"`
2. `src/tribalmemory/server/app.py` had `version="0.1.0"` hardcoded in the FastAPI app and root endpoint

## Solution
- Updated `__version__` to `0.9.0` in `__init__.py`
- Modified `app.py` to import and use `__version__` from the package instead of hardcoding
- Added comprehensive test suite in `tests/test_version.py` to:
  - Validate semver format
  - Check against known stale versions
  - Verify FastAPI app uses package version
  - Verify root endpoint returns correct version

## Testing
All new version tests pass:
```
tests/test_version.py::test_version_format PASSED
tests/test_version.py::test_version_not_stale PASSED
tests/test_version.py::test_server_uses_package_version PASSED
tests/test_version.py::test_root_endpoint_version PASSED
```

Server and service tests also pass (53 tests).